### PR TITLE
Edit: set limit to `999` to fetch all donors

### DIFF
--- a/frontend/src/components/CreateEventPage.tsx
+++ b/frontend/src/components/CreateEventPage.tsx
@@ -37,7 +37,7 @@ const CreateEventPage: React.FC = () => {
         setEventId(response.data.message);
 
         const donorResponse = await axios.get(`/api/bccancer/search-donors`, {
-          params: { cities: location, limit: 30 },
+          params: { cities: location, limit: 999 },
         });
 
         if (donorResponse.data && donorResponse.data.data) {


### PR DESCRIPTION
Set limit to 999 to fetch all donors.

If set nothing the default limit will be 10 instead of select all.

[Link](https://bc-cancer-faux.onrender.com/)